### PR TITLE
Custom boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ name | type | default | description
 **coordinates** | bool | *false* | Show a coordinate margin
 **colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`
 **css** | string | standard_standard | Piece set CSS
+**background_image** | string | *(none)* | Optional board background image (PNG, JPG, or SVG). If a filename ending in .svg, the SVG is embedded and scaled; if PNG/JPG, the image is embedded as a base64 data URI. Example: `wood1.png` or `pattern.svg`.
 
 ```
 https://backscattering.de/web-boardimage/board.svg?fen=5r1k/1b4pp/3pB1N1/p2Pq2Q/PpP5/6PK/8/8&lastMove=f4g6&check=h8&arrows=Ge6g8,Bh7&squares=a3,c3

--- a/pychess.py
+++ b/pychess.py
@@ -66,10 +66,10 @@ class Piece:
             return cls(PIECE_LETTERS.index(letter.lower()), WHITE)
 
     def __repr__(self):
-        return self.symbol()
+        return self.symbol
 
     def __str__(self):
-        return self.symbol()
+        return self.symbol
 
 
 class Move:

--- a/pychess_svg.py
+++ b/pychess_svg.py
@@ -1,7 +1,6 @@
 import pychess
 import math
 import os
-from os.path import expanduser
 from typing import Dict, Tuple, Union
 
 import svgutils
@@ -225,6 +224,15 @@ def piece(css, piece, size=None):
     return SvgWrapper(ET.tostring(svg).decode("utf-8"))
 
 
+def _colors_to_css(colors: Dict[str, str]) -> str:
+    """Convert a color mapping dictionary into a CSS string."""
+    lines = []
+    for selector, value in colors.items():
+        classes = "." + ".".join(selector.split())
+        lines.append(f"{classes} {{ fill: {value}; }}")
+    return "\n".join(lines)
+
+
 def board(css, board=None, orientation=True, flipped=False, check=None, lastmove=None, arrows=(), squares=None, width=None, height=None, colors=None, coordinates=False, borders=False, background_image=None):
     orientation ^= flipped
     inner_border = 1 if borders and coordinates else 0
@@ -234,7 +242,7 @@ def board(css, board=None, orientation=True, flipped=False, check=None, lastmove
 
     svg = _svg(board.cols * SQUARE_SIZE, board.rows * SQUARE_SIZE, width, height)
     if colors:
-        ET.SubElement(svg, "style").text = str(colors)
+        ET.SubElement(svg, "style").text = _colors_to_css(colors)
 
     if lastmove:
         lastmove_from = (board.rows - square_rank(lastmove.from_square) - 1, square_file(lastmove.from_square))

--- a/pychess_svg.py
+++ b/pychess_svg.py
@@ -340,11 +340,17 @@ def board(css, board=None, orientation=True, flipped=False, check=None, lastmove
     if render_squares:
         for y_index in range(board.rows):
             for x_index in range(board.cols):
+                if orientation:
+                    display_row = y_index
+                    display_col = x_index
+                else:
+                    display_row = board.rows - y_index - 1
+                    display_col = board.cols - x_index - 1
                 x = (x_index) * SQUARE_SIZE + margin
                 y = (y_index) * SQUARE_SIZE + margin
 
-                cls = ["square", "light" if x_index % 2 == y_index % 2 else "dark"]
-                if lastmove and (y_index, x_index) in (lastmove_from, lastmove_to):
+                cls = ["square", "light" if display_col % 2 == display_row % 2 else "dark"]
+                if lastmove and (display_row, display_col) in (lastmove_from, lastmove_to):
                     cls.append("lastmove")
                 fill_color = DEFAULT_COLORS[" ".join(cls)]
 
@@ -359,7 +365,7 @@ def board(css, board=None, orientation=True, flipped=False, check=None, lastmove
                 })
 
                 # Render selected squares.
-                if (y_index, x_index) in parse_squares(board, squares):
+                if (display_row, display_col) in parse_squares(board, squares):
                     ET.SubElement(svg, "use", _attrs({
                         "href": "#xx",
                         "xlink:href": "#xx",
@@ -371,12 +377,18 @@ def board(css, board=None, orientation=True, flipped=False, check=None, lastmove
     if board is not None:
         for y_index in range(board.rows):
             for x_index in range(board.cols):
-                x = (x_index) * SQUARE_SIZE + margin
-                y = (y_index) * SQUARE_SIZE + margin
-                piece = board.piece_at(y_index, x_index)
+                if orientation:
+                    display_row = y_index
+                    display_col = x_index
+                else:
+                    display_row = board.rows - y_index - 1
+                    display_col = board.cols - x_index - 1
+                x = x_index * SQUARE_SIZE + margin
+                y = y_index * SQUARE_SIZE + margin
+                piece = board.piece_at(display_row, display_col)
                 if piece:
                     # Render check mark.
-                    if (check is not None) and check_file_index == x_index and check_rank_index == y_index:
+                    if (check is not None) and check_file_index == display_col and check_rank_index == display_row:
                         ET.SubElement(svg, "rect", _attrs({
                             "x": x,
                             "y": y,

--- a/pychess_svg.py
+++ b/pychess_svg.py
@@ -225,7 +225,7 @@ def piece(css, piece, size=None):
     return SvgWrapper(ET.tostring(svg).decode("utf-8"))
 
 
-def board(css, board=None, orientation=True, flipped=False, check=None, lastmove=None, arrows=(), squares=None, width=None, height=None, colors=None, coordinates=False, borders=False):
+def board(css, board=None, orientation=True, flipped=False, check=None, lastmove=None, arrows=(), squares=None, width=None, height=None, colors=None, coordinates=False, borders=False, background_image=None):
     orientation ^= flipped
     inner_border = 1 if borders and coordinates else 0
     outer_border = 1 if borders else 0
@@ -253,38 +253,118 @@ def board(css, board=None, orientation=True, flipped=False, check=None, lastmove
         check_rank_index = board.rows - square_rank(check) - 1
         check_file_index = square_file(check)
 
-    # Render board
-    for y_index in range(board.rows):
-        for x_index in range(board.cols):
-            x = (x_index) * SQUARE_SIZE + margin
-            y = (y_index) * SQUARE_SIZE + margin
+    # Render board background image if provided
+    if background_image:
+        if background_image.lower().endswith('.svg'):
+            # Embed SVG background directly
+            bg_path = os.path.join('pychess-variants/static/images/board', background_image)
+            try:
+                with open(bg_path, 'r', encoding='utf-8') as f:
+                    bg_svg = f.read()
+                # Remove XML declaration if present
+                if bg_svg.startswith('<?xml'):
+                    bg_svg = bg_svg.split('?>', 1)[-1]
+                # Parse the SVG and extract width/height or viewBox
+                bg_tree = ET.fromstring(bg_svg)
+                if bg_tree.tag.endswith('svg'):
+                    width = bg_tree.get('width')
+                    height = bg_tree.get('height')
+                    viewBox = bg_tree.get('viewBox')
+                    if width and height:
+                        try:
+                            width_val = float(width.replace('px',''))
+                            height_val = float(height.replace('px',''))
+                        except Exception:
+                            width_val = board.cols * SQUARE_SIZE
+                            height_val = board.rows * SQUARE_SIZE
+                    elif viewBox:
+                        parts = viewBox.strip().split()
+                        width_val = float(parts[2])
+                        height_val = float(parts[3])
+                    else:
+                        width_val = board.cols * SQUARE_SIZE
+                        height_val = board.rows * SQUARE_SIZE
+                    # Remove <svg> wrapper, keep children
+                    bg_inner = list(bg_tree)
+                    bg_group = ET.Element('g')
+                    for elem in bg_inner:
+                        bg_group.append(elem)
+                    scale_x = (board.cols * SQUARE_SIZE) / width_val
+                    scale_y = (board.rows * SQUARE_SIZE) / height_val
+                    bg_group.set('transform', f'translate({margin}, {margin}) scale({scale_x}, {scale_y})')
+                    svg.insert(1, bg_group)
+                else:
+                    # fallback: insert as a group
+                    bg_elem = ET.fromstring(f'<g>{bg_svg}</g>')
+                    svg.insert(1, bg_elem)
+            except Exception as e:
+                print(f"ERROR: Could not embed SVG background: {e}")
+        else:
+            # Use <image> for PNG/JPG, embed as data URI
+            import base64
+            img_path = os.path.join('pychess-variants/static/images/board', background_image)
+            try:
+                with open(img_path, 'rb') as img_file:
+                    img_bytes = img_file.read()
+                ext = os.path.splitext(background_image)[1].lower()
+                if ext == '.jpg' or ext == '.jpeg':
+                    mime = 'image/jpeg'
+                elif ext == '.png':
+                    mime = 'image/png'
+                else:
+                    mime = 'application/octet-stream'
+                data_uri = f"data:{mime};base64," + base64.b64encode(img_bytes).decode('ascii')
+                ET.SubElement(svg, "image", {
+                    "{http://www.w3.org/1999/xlink}href": data_uri,
+                    "x": str(margin),
+                    "y": str(margin),
+                    "width": str(board.cols * SQUARE_SIZE),
+                    "height": str(board.rows * SQUARE_SIZE),
+                    "preserveAspectRatio": "none"
+                })
+            except Exception as e:
+                print(f"ERROR: Could not embed PNG/JPG background: {e}")
+        render_squares = False
+    else:
+        render_squares = True
 
-            cls = ["square", "light" if x_index % 2 == y_index % 2 else "dark"]
-            if lastmove and (y_index, x_index) in (lastmove_from, lastmove_to):
-                cls.append("lastmove")
-            fill_color = DEFAULT_COLORS[" ".join(cls)]
+    # Render board squares only if not using a background image
+    if render_squares:
+        for y_index in range(board.rows):
+            for x_index in range(board.cols):
+                x = (x_index) * SQUARE_SIZE + margin
+                y = (y_index) * SQUARE_SIZE + margin
 
-            ET.SubElement(svg, "rect", {
-                "x": str(x),
-                "y": str(y),
-                "width": str(SQUARE_SIZE),
-                "height": str(SQUARE_SIZE),
-                "class": " ".join(cls),
-                "stroke": "none",
-                "fill": fill_color,
-            })
+                cls = ["square", "light" if x_index % 2 == y_index % 2 else "dark"]
+                if lastmove and (y_index, x_index) in (lastmove_from, lastmove_to):
+                    cls.append("lastmove")
+                fill_color = DEFAULT_COLORS[" ".join(cls)]
 
-            # Render selected squares.
-            if (y_index, x_index) in parse_squares(board, squares):
-                ET.SubElement(svg, "use", _attrs({
-                    "href": "#xx",
-                    "xlink:href": "#xx",
-                    "x": x,
-                    "y": y,
-                }))
+                ET.SubElement(svg, "rect", {
+                    "x": str(x),
+                    "y": str(y),
+                    "width": str(SQUARE_SIZE),
+                    "height": str(SQUARE_SIZE),
+                    "class": " ".join(cls),
+                    "stroke": "none",
+                    "fill": fill_color,
+                })
 
-            # Render piece
-            if board is not None:
+                # Render selected squares.
+                if (y_index, x_index) in parse_squares(board, squares):
+                    ET.SubElement(svg, "use", _attrs({
+                        "href": "#xx",
+                        "xlink:href": "#xx",
+                        "x": x,
+                        "y": y,
+                    }))
+
+    # Render pieces
+    if board is not None:
+        for y_index in range(board.rows):
+            for x_index in range(board.cols):
+                x = (x_index) * SQUARE_SIZE + margin
+                y = (y_index) * SQUARE_SIZE + margin
                 piece = board.piece_at(y_index, x_index)
                 if piece:
                     # Render check mark.

--- a/server.py
+++ b/server.py
@@ -40,7 +40,8 @@ class Service:
     def make_svg(self, request):
         css = request.query.get("css", "standard_standard").replace("_", "/", 1)
         fen = request.query["fen"].replace(".", "+")
-        print(css, fen)
+        background_image = request.query.get("background_image")
+        print(css, fen, background_image)
         try:
             board = pychess.Board(fen, css)
         except KeyError:
@@ -104,6 +105,7 @@ class Service:
             width=width,
             height=height,
             colors=colors,
+            background_image=background_image,
         )
 
     async def render_svg(self, request):

--- a/server.py
+++ b/server.py
@@ -38,7 +38,7 @@ THEMES = {name: load_theme(name) for name in ["wikipedia", "lichess-blue", "lich
 
 class Service:
     def make_svg(self, request):
-        css = request.query.get("css", "standard_standard").replace("_", "/")
+        css = request.query.get("css", "standard_standard").replace("_", "/", 1)
         fen = request.query["fen"].replace(".", "+")
         print(css, fen)
         try:

--- a/server.py
+++ b/server.py
@@ -113,6 +113,8 @@ class Service:
 
     async def render_png(self, request):
         svg_data = self.make_svg(request)
+        if isinstance(svg_data, str):
+            svg_data = svg_data.encode("utf-8")
         png_data = cairosvg.svg2png(bytestring=svg_data)
         return aiohttp.web.Response(body=png_data, content_type="image/png")
 


### PR DESCRIPTION
This is an experimental implementation to support custom boards. I tried it for janggi svg and png board backgrounds and it looked decent for both. However, I think the background rescaling is not robust, would need to be checked.
![board (1)](https://github.com/user-attachments/assets/dca37301-42c1-4d10-abb1-0d8dab55722a)
![board (2)](https://github.com/user-attachments/assets/ea14d365-e6c6-4351-addc-2476978613d2)

For reference the corresponding requests
```
/board.svg?fen=9/3R1k3/5a3/9/9/4p3P/4B4/4K4/4A4/3C5&lastMove=d7d9&check=f9&arrows=Gd9f9,Bf9&squares=a3,c3&css=janggi_janggihb&background_image=Janggi.svg
```
```
/board.svg?fen=9/3R1k3/5a3/9/9/4p3P/4B4/4K4/4A4/3C5&lastMove=d7d9&check=f9&arrows=Gd9f9,Bf9&squares=a3,c3&css=janggi_janggihb&background_image=JanggiPaper.png
```